### PR TITLE
Check options object for defines setting and update build command.

### DIFF
--- a/lib/libBuilder.js
+++ b/lib/libBuilder.js
@@ -107,6 +107,10 @@ builder.createCommand = function createCommand ( options, fileObj ) {
   if (options.namespaces && options.namespaces.length) {
     cmd += cHelpers.makeParam( options.namespaces, '-n' );
   }
+  // check for defines
+  if (options.define && options.define.length) {
+    cmd += cHelpers.makeParam( options.define, '--define' );
+  }
   // append root
   var allRoots = gruntMod.file.expand( fileObj.src );
   cmd += cHelpers.makeParam( allRoots, '--root=', true, true);


### PR DESCRIPTION
Closure Compiler offers a `define` option for compilation-time overrides. This patch checks for the `define` options and modifies the build command accordingly.
